### PR TITLE
fix: back button not working in component view of a filtered unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@testing-library/react": "^16.0.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
-    "eslint": "^9.0.0",
+    "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-plugin-import": "^2.31.0",

--- a/src/components/AspectsSidebar/index.test.tsx
+++ b/src/components/AspectsSidebar/index.test.tsx
@@ -1,0 +1,235 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BlockTypes } from '../../constants';
+import { AspectsSidebar, ContentList } from '.';
+import { useAspectsSidebarContext } from '../../hooks';
+import messages from '../../messages';
+import '@testing-library/jest-dom';
+import { Block } from '../../types';
+
+// Mock dependencies
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  defineMessages: jest.fn((messageObject) => messageObject),
+  useIntl: () => ({
+    formatMessage: (message: { defaultMessage: string }) => message.defaultMessage,
+  }),
+}));
+
+const mockDashboard = jest.fn();
+jest.mock('./Dashboard', () => ({
+  Dashboard: () => mockDashboard,
+}));
+
+// Mock the IntersectionObserver window API
+const intersectionObserverMock = () => ({
+  observe: () => null,
+  unobserve: () => null,
+});
+window.IntersectionObserver = jest.fn().mockImplementation(intersectionObserverMock);
+
+const mockUnit: Block = {
+  id: 'block-v1:test-block',
+  type: BlockTypes.vertical,
+  displayName: 'Test Unit',
+  graded: false,
+};
+const mockContentLists: ContentList[] = [
+  {
+    title: 'Problem Blocks',
+    blocks: [
+      {
+        id: 'block-v1:TEST+COURSE+SECTION1+prob1',
+        type: BlockTypes.problem,
+        displayName: 'Problem 1',
+        graded: false,
+      },
+      {
+        id: 'block-v1:TEST+COURSE+SECTION1+prob2',
+        type: BlockTypes.problem,
+        displayName: 'Problem 2',
+        graded: true,
+      },
+    ],
+  },
+  {
+    title: 'Video Blocks',
+    blocks: [
+      {
+        id: 'block-v1:TEST+COURSE+SECTION2+vidoe1',
+        type: BlockTypes.video,
+        displayName: 'Video',
+        graded: false,
+      },
+    ],
+  },
+];
+const defaultProps = {
+  title: 'Test Course',
+  blockType: BlockTypes.course,
+  dashboardId: 'course-v1:TEST+COURSE',
+  contentLists: mockContentLists,
+};
+
+type InitialState = {
+  sidebarOpen: boolean,
+  activeBlock?: Block | null,
+  filterUnit?: Block | null,
+  filteredBlocks?: string[]
+};
+
+// Helper component to set context values for tests
+function TestContextHelper({
+  sidebarOpen = true, activeBlock = null, filterUnit = null, filteredBlocks = [],
+}: InitialState) {
+  const {
+    setSidebarOpen, setActiveBlock, setFilterUnit, setFilteredBlocks,
+  } = useAspectsSidebarContext();
+
+  // This effect is run only one to set the initial state for the tests.
+  React.useEffect(() => {
+    setSidebarOpen(sidebarOpen);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // The sidebar will clear active/filter stuff to render cleanly on initalization
+  // So, we can't set these values in the useEffect above. The only way to cleanly
+  // do it is by userEvent.click - simulating real-world scenario
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setActiveBlock(activeBlock);
+        setFilterUnit(filterUnit);
+        setFilteredBlocks(filteredBlocks);
+      }}
+    >
+      Activate Unit
+    </button>
+  );
+}
+
+describe('AspectsSidebar', () => {
+  const renderComponent = (
+    initialState: InitialState = { sidebarOpen: true },
+    props?: Partial<React.ComponentProps<typeof AspectsSidebar>>,
+  ) => render(
+
+    <>
+      <TestContextHelper {...initialState} />
+      <AspectsSidebar
+        {...defaultProps}
+        {...props}
+      />
+    </>,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('closes the sidebar when the close button is clicked', async () => {
+    renderComponent();
+    // Ensure the sidebar is initially open and visible
+    expect(screen.getByTestId('sidebar')).toBeVisible();
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent('Test Course');
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    fireEvent.click(closeButton);
+
+    // Assert that the sidebar is no longer visible
+    expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument();
+  });
+
+  it('shows the back button and changes the title when a block is clicked', () => {
+    renderComponent();
+
+    const problemBlockButton = screen.getByRole('button', { name: /Problem 1/ });
+    fireEvent.click(problemBlockButton);
+
+    // Verify the back button is visible
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    expect(backButton).toBeVisible();
+
+    // Verify the sidebar title has changed to the block's display name
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent('Problem 1');
+  });
+
+  it('navigates back to the course title when clicking the back button from a block view', () => {
+    renderComponent();
+
+    const videoBlock = screen.getByRole('button', { name: /Video/i });
+    fireEvent.click(videoBlock);
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent('Video');
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    fireEvent.click(backButton);
+
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent(defaultProps.title);
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+  });
+
+  it('shows an Alert message when the content lists are empty on a Unit Page', () => {
+    // NOTE: Currently there is not "Unit Page Dashboard", hence the alert
+    renderComponent({ sidebarOpen: true }, { blockType: BlockTypes.vertical, contentLists: [] });
+
+    expect(mockDashboard).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(messages.noAnalyticsForUnit.defaultMessage);
+  });
+
+  it('shows filtered set of components in the Course Outline view when specific unit is selected', () => {
+    // render the component as if the "UnitActionsButton" has been clicked
+    renderComponent({
+      sidebarOpen: true,
+      activeBlock: mockUnit,
+      filterUnit: mockUnit,
+      filteredBlocks: ['block-v1:TEST+COURSE+SECTION1+prob2'],
+    });
+    fireEvent.click(screen.getByText('Activate Unit'));
+
+    // It should show the unit title on top and only one problem block that's part of the unit
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent(mockUnit.displayName);
+    expect(screen.getByRole('button', { name: 'Back' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Problem 1' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Problem 2' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Video' })).not.toBeInTheDocument();
+  });
+
+  it('navigate to component and back in filtered unit view', () => {
+    renderComponent({
+      sidebarOpen: true,
+      activeBlock: mockUnit,
+      filterUnit: mockUnit,
+      filteredBlocks: ['block-v1:TEST+COURSE+SECTION1+prob2'],
+    });
+    fireEvent.click(screen.getByText('Activate Unit'));
+
+    // Looking at the filtered unit view
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent(mockUnit.displayName);
+    expect(screen.getByRole('button', { name: 'Back' })).toBeVisible();
+
+    // Go to component View
+    fireEvent.click(screen.getByRole('button', { name: 'Problem 2' }));
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent('Problem 2');
+
+    // Come back to filtered Unit View
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent(mockUnit.displayName);
+
+    // return all the way back to course view
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByTestId('sidebar-title')).toHaveTextContent(defaultProps.title);
+  });
+
+  it('posts a callback with the activatedBlock in Unit Page View', () => {
+    const callback = jest.fn();
+    renderComponent({ sidebarOpen: true }, {
+      title: 'Test Unit',
+      blockType: BlockTypes.vertical,
+      contentLists: mockContentLists.slice(0, 1),
+      blockActivatedCallback: callback,
+      dashboardId: 'test-dashboard',
+    });
+
+    // click on a problem block
+    fireEvent.click(screen.getByRole('button', { name: mockContentLists[0].blocks[0].displayName }));
+    expect(callback).toHaveBeenCalledWith(mockContentLists[0].blocks[0]);
+  });
+});

--- a/src/components/AspectsSidebar/index.tsx
+++ b/src/components/AspectsSidebar/index.tsx
@@ -37,7 +37,7 @@ export function AspectsSidebar({
   const intl = useIntl();
   const {
     sidebarOpen, setSidebarOpen, setFilteredBlocks, activeBlock, setActiveBlock,
-    filterUnit, setFilterUnit,
+    filterUnit, setFilterUnit, filteredBlocks,
   } = useAspectsSidebarContext();
 
   // The activeBlock is not reset during page navigations, leading to stale dashboards.
@@ -88,7 +88,7 @@ export function AspectsSidebar({
   };
 
   return (
-    <div className="w-100 h-100">
+    <div className="w-100 h-100" data-testid="sidebar">
       <Sticky className="shadow rounded" offset={2}>
         <div className="bg-white rounded w-100">
           <Stack className="sidebar-header">
@@ -117,7 +117,7 @@ export function AspectsSidebar({
                 size="sm"
               />
             </Stack>
-            <h3 className="h3 px-4 pb-4 mb-0 d-flex align-items-center">
+            <h3 className="h3 px-4 pb-4 mb-0 d-flex align-items-center" data-testid="sidebar-title">
               {(activeBlock) && (
                 <IconButton
                   className="mr-2"
@@ -140,12 +140,12 @@ export function AspectsSidebar({
           { !hideDashboard && (
             <Dashboard usageKey={activeBlock?.id || dashboardId} title={topTitle} />
           )}
-          {((activeBlockType === 'course') || (activeBlockType === 'vertical'))
+          {((activeBlockType === BlockTypes.course) || (activeBlockType === BlockTypes.vertical))
             && contentLists.map(({ title: listTitle, blocks }) => (
               <CourseContentList
                 key={listTitle}
                 title={listTitle}
-                blocks={blocks}
+                blocks={filteredBlocks.length ? blocks.filter((block) => filteredBlocks.includes(block.id)) : blocks}
                 activateDashboard={activateDashboard}
               />
             ))}

--- a/src/components/AspectsSidebar/index.tsx
+++ b/src/components/AspectsSidebar/index.tsx
@@ -14,7 +14,7 @@ import { CourseContentList } from './CourseContentList';
 import { Dashboard } from './Dashboard';
 import { Block } from '../../types';
 
-type ContentList = {
+export type ContentList = {
   title: string;
   blocks: Block[];
 };

--- a/src/components/CourseOutlineSidebar.test.tsx
+++ b/src/components/CourseOutlineSidebar.test.tsx
@@ -269,59 +269,8 @@ describe('CourseOutlineSidebar', () => {
     mockUseAspectsSidebarContext.mockReturnValue({ filteredBlocks: ['problem1'] }); // Filtering active
     renderComponent({ sections: mockSections });
 
-    const expectedProblemTitle = messages.problemAnalytics.defaultMessage;
-
-    expect(MockAspectsSidebar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        contentLists: [
-          {
-            title: expectedProblemTitle,
-            blocks: [mockProblems[0]], // Only problem1 due to filter
-          },
-          // Videos list would be empty due to filter, so not included
-        ],
-      }),
-      {},
-    );
-  });
-
-  it('filters problems based on filteredBlocks from context', () => {
-    mockUseCourseBlocks.mockReturnValue({ data: { problems: mockProblems, videos: [] } });
-    mockUseAspectsSidebarContext.mockReturnValue({ filteredBlocks: ['problem2'] }); // Filter for problem2
-    renderComponent({ sections: [] });
-
-    const expectedProblemTitle = messages.problemAnalytics.defaultMessage;
-
-    expect(MockAspectsSidebar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        contentLists: [
-          {
-            title: expectedProblemTitle,
-            blocks: [mockProblems[1]], // Only problem2
-          },
-        ],
-      }),
-      {},
-    );
-  });
-
-  it('filters videos based on filteredBlocks from context', () => {
-    mockUseCourseBlocks.mockReturnValue({ data: { problems: [], videos: mockVideos } });
-    mockUseAspectsSidebarContext.mockReturnValue({ filteredBlocks: ['video1'] }); // Filter for video1
-    renderComponent({ sections: [] });
-
-    const expectedVideoTitle = messages.videoAnalytics.defaultMessage;
-
-    expect(MockAspectsSidebar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        contentLists: [
-          {
-            title: expectedVideoTitle,
-            blocks: [mockVideos[0]], // Only video1
-          },
-        ],
-      }),
-      {},
+    expect(MockAspectsSidebar.mock.calls[0][0].contentLists[0].title).not.toEqual(
+      messages.gradedSubsectionAnalytics.defaultMessage,
     );
   });
 

--- a/src/components/CourseOutlineSidebar.tsx
+++ b/src/components/CourseOutlineSidebar.tsx
@@ -28,13 +28,9 @@ export function CourseOutlineSidebar({ courseId, courseName, sections }: Props) 
   const { data } = useCourseBlocks(courseId);
 
   const gradedSubsections = sections ? Array.from(getGradedSubsections(sections)) : null;
-  let problems = data?.problems;
-  let videos = data?.videos;
+  const problems = data?.problems;
+  const videos = data?.videos;
 
-  if (filteredBlocks?.length) {
-    problems = problems?.filter(block => filteredBlocks.includes(block.id));
-    videos = videos?.filter(block => filteredBlocks.includes(block.id));
-  }
   const contentLists: { title: string, blocks: Block[] }[] = [];
 
   // graded subsections are shown only when unit-filtering is off

--- a/src/components/UnitPageSidebar.test.tsx
+++ b/src/components/UnitPageSidebar.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { XBlock } from '../types';
+import { XBlock, Block } from '../types';
 import { UnitPageSidebar } from './UnitPageSidebar';
 import { AspectsSidebar } from './AspectsSidebar';
 import { BlockTypes } from '../constants';
 
 // Mock the AspectsSidebar for testing the props
+const mockSendMessageToIframe = jest.fn();
 jest.mock('./AspectsSidebar', () => ({
   AspectsSidebar: jest.fn(),
 }));
@@ -15,7 +16,7 @@ jest.mock(
   'CourseAuthoring/generic/hooks/context/hooks',
   () => ({
     useIframe: jest.fn(() => ({
-      sendMessageToIframe: jest.fn(),
+      sendMessageToIframe: mockSendMessageToIframe,
     })),
   }),
   { virtual: true },
@@ -42,7 +43,7 @@ const mockXBlocks: XBlock[] = [
 ];
 
 describe('UnitPageSidebar', () => {
-  const MockAspectsSidebar = AspectsSidebar;
+  const MockAspectsSidebar = AspectsSidebar as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -126,5 +127,29 @@ describe('UnitPageSidebar', () => {
       },
       {},
     );
+  });
+
+  it('calls sendMessageToIframe with the correct arguments when blockActivatedCallback is invoked', () => {
+    renderComponent();
+
+    // Get the blockActivatedCallback from the mock call arguments
+    const callback = MockAspectsSidebar.mock.calls[0][0].blockActivatedCallback;
+
+    // Define a mock Block object
+    const mockBlock: Block = {
+      id: 'mock-block-id',
+      type: 'mock-block-type',
+      displayName: 'Mock Block',
+      graded: false,
+    };
+
+    // Call the callback with the mock Block
+    callback(mockBlock);
+
+    // Assert that sendMessageToIframe was called correctly
+    expect(mockSendMessageToIframe).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageToIframe).toHaveBeenCalledWith('scrollToXBlock', {
+      locator: mockBlock.id,
+    });
   });
 });

--- a/src/components/UnitPageSidebar.test.tsx
+++ b/src/components/UnitPageSidebar.test.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { XBlock } from '../types';
+import { UnitPageSidebar } from './UnitPageSidebar';
+import { AspectsSidebar } from './AspectsSidebar';
+import { BlockTypes } from '../constants';
+
+// Mock the AspectsSidebar for testing the props
+jest.mock('./AspectsSidebar', () => ({
+  AspectsSidebar: jest.fn(),
+}));
+
+// Mocks the hooks
+jest.mock(
+  'CourseAuthoring/generic/hooks/context/hooks',
+  () => ({
+    useIframe: jest.fn(() => ({
+      sendMessageToIframe: jest.fn(),
+    })),
+  }),
+  { virtual: true },
+);
+
+const mockBlockId = 'block-v1:TestX+TST101+2025@vertical-block:12345';
+const mockUnitTitle = 'Test Unit';
+const mockXBlocks: XBlock[] = [
+  {
+    id: 'block-v1:TestX+TST101+2025@html+block@abcdef123456',
+    name: 'Introduction Text',
+    blockType: 'html',
+  },
+  {
+    id: 'block-v1:TestX+TST101+2025@video+block@fedcba654321',
+    name: 'Welcome Video',
+    blockType: 'video',
+  },
+  {
+    id: 'block-v1:TestX+TST101+2025@problem+block@123abc456def',
+    name: 'Knowledge Check',
+    blockType: 'problem',
+  },
+];
+
+describe('UnitPageSidebar', () => {
+  const MockAspectsSidebar = AspectsSidebar;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderComponent = (
+    props: Partial<React.ComponentProps<typeof UnitPageSidebar>> = {},
+  ) => {
+    const defaultProps = {
+      blockId: mockBlockId,
+      unitTitle: mockUnitTitle,
+      xBlocks: mockXBlocks,
+    };
+    return render(<UnitPageSidebar {...defaultProps} {...props} />);
+  };
+
+  it('renders the sidebar with the right props', () => {
+    renderComponent();
+
+    expect(MockAspectsSidebar).toHaveBeenCalledTimes(1);
+    expect(MockAspectsSidebar).toHaveBeenCalledWith(
+      {
+        title: mockUnitTitle,
+        blockType: BlockTypes.vertical,
+        dashboardId: mockBlockId,
+        contentLists: [
+          {
+            // no title for the content lists in unit page, as they are not grouped
+            title: '',
+            // blocks are filtered to include only problem and video blocks
+            blocks: [
+              {
+                id: 'block-v1:TestX+TST101+2025@video+block@fedcba654321',
+                type: BlockTypes.video,
+                displayName: 'Welcome Video',
+                graded: false,
+              },
+              {
+                id: 'block-v1:TestX+TST101+2025@problem+block@123abc456def',
+                type: BlockTypes.problem,
+                displayName: 'Knowledge Check',
+                graded: false,
+              },
+            ],
+          },
+        ],
+        blockActivatedCallback: expect.any(Function),
+      },
+      {},
+    );
+  });
+
+  it('renders the sidebar with an empty content list when xBlocks is null', () => {
+    // @ts-ignore - accept null for testing purposes only
+    renderComponent({ xBlocks: null });
+
+    expect(MockAspectsSidebar).toHaveBeenCalledTimes(1);
+    expect(MockAspectsSidebar).toHaveBeenCalledWith(
+      {
+        title: mockUnitTitle,
+        blockType: BlockTypes.vertical,
+        dashboardId: mockBlockId,
+        contentLists: [], // Expect empty contentLists
+        blockActivatedCallback: expect.any(Function),
+      },
+      {},
+    );
+  });
+
+  it('renders the sidebar with an empty content list when xBlocks is an empty array', () => {
+    renderComponent({ xBlocks: [] });
+
+    expect(MockAspectsSidebar).toHaveBeenCalledTimes(1);
+    expect(MockAspectsSidebar).toHaveBeenCalledWith(
+      {
+        title: mockUnitTitle,
+        blockType: BlockTypes.vertical,
+        dashboardId: mockBlockId,
+        contentLists: [], // Expect empty contentLists
+        blockActivatedCallback: expect.any(Function),
+      },
+      {},
+    );
+  });
+});

--- a/src/components/UnitPageSidebar.test.tsx
+++ b/src/components/UnitPageSidebar.test.tsx
@@ -134,8 +134,6 @@ describe('UnitPageSidebar', () => {
 
     // Get the blockActivatedCallback from the mock call arguments
     const callback = MockAspectsSidebar.mock.calls[0][0].blockActivatedCallback;
-
-    // Define a mock Block object
     const mockBlock: Block = {
       id: 'mock-block-id',
       type: 'mock-block-type',
@@ -143,10 +141,8 @@ describe('UnitPageSidebar', () => {
       graded: false,
     };
 
-    // Call the callback with the mock Block
     callback(mockBlock);
 
-    // Assert that sendMessageToIframe was called correctly
     expect(mockSendMessageToIframe).toHaveBeenCalledTimes(1);
     expect(mockSendMessageToIframe).toHaveBeenCalledWith('scrollToXBlock', {
       locator: mockBlock.id,

--- a/src/components/UnitPageSidebar.tsx
+++ b/src/components/UnitPageSidebar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 // @ts-ignore
 import { useIframe } from 'CourseAuthoring/generic/hooks/context/hooks';
 import { BlockTypes } from '../constants';
-import { AspectsSidebar } from './AspectsSidebar';
+import { AspectsSidebar, ContentList } from './AspectsSidebar';
 import { castToBlock, XBlock, Block } from '../types';
 
 interface Props {
@@ -15,23 +15,21 @@ export function UnitPageSidebar({
   blockId, unitTitle, xBlocks,
 }: Props) {
   const { sendMessageToIframe } = useIframe();
-  const contentList = {
-    title: '',
-    blocks: React.useMemo(
-      () => {
-        const blocks = castToBlock(xBlocks) as Block[];
-        return blocks.filter(block => (block.type === 'problem') || (block.type === 'video'));
-      },
-      [xBlocks],
-    ),
-  };
+  const contentLists: ContentList[] = [];
+  if (xBlocks && xBlocks.length) {
+    const blocks = castToBlock(xBlocks) as Block[];
+    contentLists.push({
+      title: '',
+      blocks: blocks.filter(block => (block.type === 'problem') || (block.type === 'video')),
+    });
+  }
 
   return (
     <AspectsSidebar
       title={unitTitle}
       blockType={BlockTypes.vertical}
       dashboardId={blockId}
-      contentLists={[contentList]}
+      contentLists={contentLists}
       blockActivatedCallback={(block: Block) => sendMessageToIframe('scrollToXBlock', { locator: block.id })}
     />
   );

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -134,7 +134,7 @@ export const useAspectsSidebarContext = (): SidebarContext => {
       state.sidebarOpen.set(value);
     },
     setActiveBlock: (value: Block | null) => {
-      state.activeBlock.set(value);
+      state.activeBlock.set(JSON.parse(JSON.stringify(value)));
     },
     setFilteredBlocks: (value: string[]) => {
       state.filteredBlocks.set(value);


### PR DESCRIPTION
This fixes the error when the activeBlock is set to the same value as the filterUnit, the hookState runs into HOOKSTATE-102 error, causing the button to not work.

Ref: https://github.com/openedx/openedx-aspects/issues/317

# Testing

With the plugin setup, follow the steps in https://github.com/openedx/openedx-aspects/issues/317 and verify that the bug is fixed.